### PR TITLE
Added Swift Package Manager support

### DIFF
--- a/ColorCompatibility.podspec
+++ b/ColorCompatibility.podspec
@@ -22,6 +22,6 @@ In iOS 13, Apple introduced a bunch of new system colors (label, systemBackgroun
 
   s.ios.deployment_target = '9.0'
 
-  s.source_files = 'ColorCompatibility.swift'
+  s.source_files = 'Sources/ColorCompatibility.swift'
   s.swift_versions = ['3.2', '4.0', '4.1', '4.2', '5.0', '5.1']
 end

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,18 @@
+// swift-tools-version:5.1
+
+import PackageDescription
+
+let package = Package(
+    name: "ColorCompatibility",
+    platforms: [
+        .iOS(.v8),
+        .tvOS(.v9),
+    ],
+    products: [
+        .library(name: "ColorCompatibility", targets: ["ColorCompatibility"]),
+    ],
+    targets: [
+        .target(name: "ColorCompatibility", path: "Sources"),
+    ],
+    swiftLanguageVersions: [.v5]
+)

--- a/Sources/ColorCompatibility.swift
+++ b/Sources/ColorCompatibility.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 public enum ColorCompatibility {
     public static var label: UIColor {
         if #available(iOS 13, *) {


### PR DESCRIPTION
SPM requires code to be in separate directory, so I've created one called `Sources` and updated the podspec to match.

Have specified support for iOS8 and tvOS9 as these are the earliest SPM supports.

Have specified support for Swift 5 only, as this was the first version of SPM which included support for iOS.